### PR TITLE
Fixing missing objects in Schema

### DIFF
--- a/v1/openapi.json
+++ b/v1/openapi.json
@@ -36,12 +36,17 @@
         ],
         "description": "Specifies the structure under which a bank account is owned. Currently\nreturned values are `INDIVIDUAL` and `JOINT`.\n"
       },
-      "PurchaseMethodEnum": {
+      "CardPurchaseMethodEnum": {
         "enum": [
           "CONTACTLESS",
           "PLASTIC",
           "CARD_ON_FILE",
-          "CARD_DETAILS"
+          "CARD_DETAILS",
+          "OCR",
+          "MAGNETIC_STRIPE",
+          "ECOMMERCE",
+          "CARD_PIN",
+          "BAR_CODE"
         ]
       },
       "CardPurchaseObject": {
@@ -51,7 +56,7 @@
           "method": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/PurchaseMethodEnum"
+                "$ref": "#/components/schemas/CardPurchaseMethodEnum"
               }
             ],
             "description": "The card method used for this purchase.\n"
@@ -827,7 +832,7 @@
               },
               "cardPurchaseMethod": {
                 "nullable": true,
-                "description": "Details about what card was used for the transaction.\n",
+                "description": "Information about the card used for this transaction, if applicable.\n",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/CardPurchaseObject"
@@ -836,13 +841,13 @@
               },
               "transactionType": {
                 "type": "string",
-                "nullable": false,
-                "description": "The type of transaction that occurred.\n"
+                "nullable": true,
+                "description": "A description of the transaction method used e.g. Purchase, BPAY Payment.\n"
               },
               "note": {
                 "type": "string",
                 "nullable": true,
-                "description": "Not sure what this is"
+                "description": "A customer provided note about the transaction. Can only be provided by Up High subscribers.\n"
               },
               "performingCustomer": {
                 "nullable": false,

--- a/v1/openapi.json
+++ b/v1/openapi.json
@@ -857,7 +857,7 @@
               },
               "note": {
                 "nullable": true,
-                "description": "A customer provided note about the transaction. Can only be provided by Up High subscribers.\n"
+                "description": "A customer provided note about the transaction. Can only be provided by Up High subscribers.\n",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/NoteObject"
@@ -937,7 +937,6 @@
                 "properties": {
                   "data": {
                     "type": "object",
-                    "nullable": true,
                     "properties": {
                       "type": {
                         "type": "string",

--- a/v1/openapi.json
+++ b/v1/openapi.json
@@ -1102,7 +1102,7 @@
                     "properties": {
                       "type": {
                         "type": "string",
-                        "description": "The type of this resource: `categories`"
+                        "description": "The type of this resource: `attachments`"
                       },
                       "id": {
                         "type": "string",

--- a/v1/openapi.json
+++ b/v1/openapi.json
@@ -36,6 +36,36 @@
         ],
         "description": "Specifies the structure under which a bank account is owned. Currently\nreturned values are `INDIVIDUAL` and `JOINT`.\n"
       },
+      "PurchaseMethodEnum": {
+        "enum": [
+          "CONTACTLESS",
+          "PLASTIC",
+          "CARD_ON_FILE",
+          "CARD_DETAILS"
+        ]
+      },
+      "CardPurchaseObject": {
+        "type": "object",
+        "description": "Provides information about the type of card\n",
+        "properties": {
+            "method": {
+                "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PurchaseMethodEnum"
+                    }
+                ],
+              "description": "The card method used for this purchase.\n"
+            },
+            "cardNumberSuffix": {
+              "type": "string",
+              "description": "The last four digits of the card used for this transaction.\n"
+            }
+        },
+        "required": [
+          "method",
+          "cardNumberSuffix"
+        ]
+      },
       "MoneyObject": {
         "type": "object",
         "description": "Provides information about a value of money.\n",

--- a/v1/openapi.json
+++ b/v1/openapi.json
@@ -194,7 +194,7 @@
               "description": "Not sure what this is"
             }
           }
-        }
+        },
         "required": [
           "type",
           "id",

--- a/v1/openapi.json
+++ b/v1/openapi.json
@@ -49,7 +49,7 @@
           "BAR_CODE"
         ]
       },
-      "CardPurchaseObject": {
+      "CardPurchaseMethodObject": {
         "type": "object",
         "description": "Provides information about the type of card\n",
         "properties": {
@@ -835,7 +835,7 @@
                 "description": "Information about the card used for this transaction, if applicable.\n",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/CardPurchaseObject"
+                    "$ref": "#/components/schemas/CardPurchaseMethodObject"
                   }
                 ]
               },

--- a/v1/openapi.json
+++ b/v1/openapi.json
@@ -48,23 +48,33 @@
         "type": "object",
         "description": "Provides information about the type of card\n",
         "properties": {
-            "method": {
-                "allOf": [
-                    {
-                      "$ref": "#/components/schemas/PurchaseMethodEnum"
-                    }
-                ],
-              "description": "The card method used for this purchase.\n"
-            },
-            "cardNumberSuffix": {
-              "type": "string",
-              "description": "The last four digits of the card used for this transaction.\n"
-            }
+          "method": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PurchaseMethodEnum"
+              }
+            ],
+            "description": "The card method used for this purchase.\n"
+          },
+          "cardNumberSuffix": {
+            "type": "string",
+            "description": "The last four digits of the card used for this transaction.\n"
+          }
         },
         "required": [
           "method",
           "cardNumberSuffix"
         ]
+      },
+      "PerformingCustomer": {
+        "type": "object",
+        "description": "Information about the customer who performed the transaction.\n",
+        "properties": {
+          "displayName": {
+            "type": "string",
+            "description": "The customers Up Name.\n"
+          }
+        }
       },
       "MoneyObject": {
         "type": "object",
@@ -182,17 +192,6 @@
             "required": [
               "self"
             ]
-          }
-        },
-        "attachment": {
-          "type": "object",
-          "nullable": true,
-          "properties": {
-            "data": {
-              "type": "string",
-              "nullable": true,
-              "description": "Not sure what this is"
-            }
           }
         },
         "required": [
@@ -835,24 +834,25 @@
                   }
                 ]
               },
-            "transactionType": {
-              "type": "string",
-              "nullable": false,
-              "description": "The type of transaction that occurred.\n"
-            },
-            "note": {
-              "type": "string",
-              "nullable": true,
-              "description": "Not sure what this is"
-            },
-            "performingCustomer": {
-              "nullable": false,
-              "description": "The Up Name of the person who performed the transaction.\n",
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/PerformingCustomer"
-                }
-              ]
+              "transactionType": {
+                "type": "string",
+                "nullable": false,
+                "description": "The type of transaction that occurred.\n"
+              },
+              "note": {
+                "type": "string",
+                "nullable": true,
+                "description": "Not sure what this is"
+              },
+              "performingCustomer": {
+                "nullable": false,
+                "description": "The Up Name of the person who performed the transaction.\n",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PerformingCustomer"
+                  }
+                ]
+              }
             },
             "required": [
               "status",
@@ -866,7 +866,10 @@
               "amount",
               "foreignAmount",
               "settledAt",
-              "createdAt"
+              "createdAt",
+              "trasactionType",
+              "note",
+              "performingCustomer"
             ]
           },
           "relationships": {
@@ -911,6 +914,7 @@
               },
               "transferAccount": {
                 "type": "object",
+                "nullable": true,
                 "properties": {
                   "data": {
                     "type": "object",
@@ -1067,6 +1071,17 @@
                 "required": [
                   "data"
                 ]
+              },
+              "attachment": {
+                "type": "object",
+                "nullable": true,
+                "properties": {
+                  "data": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Not sure what this is"
+                  }
+                }
               }
             },
             "required": [
@@ -1074,7 +1089,8 @@
               "transferAccount",
               "category",
               "parentCategory",
-              "tags"
+              "tags",
+              "attachment"
             ]
           },
           "links": {

--- a/v1/openapi.json
+++ b/v1/openapi.json
@@ -63,6 +63,7 @@
           },
           "cardNumberSuffix": {
             "type": "string",
+            "nullable": true,
             "description": "The last four digits of the card used for this transaction.\n"
           }
         },

--- a/v1/openapi.json
+++ b/v1/openapi.json
@@ -184,6 +184,17 @@
             ]
           }
         },
+        "attachment": {
+          "type": "object",
+          "nullable": true,
+          "properties": {
+            "data": {
+              "type": "string",
+              "nullable": true,
+              "description": "Not sure what this is"
+            }
+          }
+        }
         "required": [
           "type",
           "id",

--- a/v1/openapi.json
+++ b/v1/openapi.json
@@ -72,7 +72,7 @@
           "cardNumberSuffix"
         ]
       },
-      "PerformingCustomer": {
+      "CustomerObject": {
         "type": "object",
         "description": "Information about the customer who performed the transaction.\n",
         "properties": {
@@ -660,6 +660,16 @@
         ],
         "description": "Specifies which stage of processing a transaction is currently at.\nCurrently returned values are `HELD` and `SETTLED`. When a transaction is\nheld, its account’s `availableBalance` is affected. When a transaction is\nsettled, its account’s `currentBalance` is affected.\n"
       },
+      "NoteObject": {
+        "type": "object",
+        "description": "A customer provided note about the transaction. Can only be provided by Up High subscribers.",
+        "properties": {
+          "text": {
+            "nullable": false,
+            "type": "string"
+          }
+        }
+      },
       "HoldInfoObject": {
         "type": "object",
         "description": "Provides information about the amount at which a transaction was in the\n`HELD` status.\n",
@@ -846,16 +856,20 @@
                 "description": "A description of the transaction method used e.g. Purchase, BPAY Payment.\n"
               },
               "note": {
-                "type": "string",
                 "nullable": true,
                 "description": "A customer provided note about the transaction. Can only be provided by Up High subscribers.\n"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NoteObject"
+                  }
+                ]
               },
               "performingCustomer": {
-                "nullable": false,
+                "nullable": true,
                 "description": "The Up Name of the person who performed the transaction.\n",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/PerformingCustomer"
+                    "$ref": "#/components/schemas/CustomerObject"
                   }
                 ]
               }
@@ -920,10 +934,10 @@
               },
               "transferAccount": {
                 "type": "object",
-                "nullable": true,
                 "properties": {
                   "data": {
                     "type": "object",
+                    "nullable": true,
                     "properties": {
                       "type": {
                         "type": "string",
@@ -942,6 +956,7 @@
                   },
                   "links": {
                     "type": "object",
+                    "nullable": true,
                     "properties": {
                       "related": {
                         "type": "string",
@@ -1083,9 +1098,34 @@
                 "nullable": true,
                 "properties": {
                   "data": {
-                    "type": "string",
-                    "nullable": true,
-                    "description": "Not sure what this is"
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "The type of this resource: `categories`"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the resource within its type.\n"
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "id"
+                    ],
+                    "nullable": true
+                  },
+                  "links": {
+                    "type": "object",
+                    "properties": {
+                      "related": {
+                        "type": "string",
+                        "description": "The link to retrieve the related resource(s) in this relationship.\n"
+                      }
+                    },
+                    "required": [
+                      "related"
+                    ]
                   }
                 }
               }

--- a/v1/openapi.json
+++ b/v1/openapi.json
@@ -814,7 +814,34 @@
                 "type": "string",
                 "format": "date-time",
                 "description": "The date-time at which this transaction was first encountered.\n"
-              }
+              },
+              "cardPurchaseMethod": {
+                "nullable": true,
+                "description": "Details about what card was used for the transaction.\n",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/CardPurchaseObject"
+                  }
+                ]
+              },
+            "transactionType": {
+              "type": "string",
+              "nullable": false,
+              "description": "The type of transaction that occurred.\n"
+            },
+            "note": {
+              "type": "string",
+              "nullable": true,
+              "description": "Not sure what this is"
+            },
+            "performingCustomer": {
+              "nullable": false,
+              "description": "The Up Name of the person who performed the transaction.\n",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/PerformingCustomer"
+                }
+              ]
             },
             "required": [
               "status",


### PR DESCRIPTION
I was using this with a Golang OpenApi client generator and I kept on running into deserialisation errors as there were missing properties in the schema.

I made a best effort to try and fill in the types & enum values as much as possible but I could've missed something.

I added the properties:
* `PurchaseMethodEnum`
* `CardPurchaseObject`
* `cardPurchaseMethod`
* `trasactionType`
* `attachments`